### PR TITLE
Fix jump_horizontal_boost direction

### DIFF
--- a/addons/2d_essentials/movement/motion/platformer_movement_component.gd
+++ b/addons/2d_essentials/movement/motion/platformer_movement_component.gd
@@ -305,7 +305,7 @@ func jump(height: float = jump_height, bypass: bool = false) -> GodotEssentialsP
 		velocity.y = _calculate_jump_velocity(height - height_reduced)
 		
 		if jump_horizontal_boost > 0:
-			velocity.x += sign(velocity.x) + jump_horizontal_boost
+			velocity.x += sign(velocity.x) * jump_horizontal_boost
 
 		_add_position_to_jump_queue(body.global_position)
 		jumped.emit(body.global_position)


### PR DESCRIPTION
Fixes #6 

The horizontal boost was accidentally being added to the direction sign, rather than multiplied by it, so you'd always jump in the positive direction and by 1 more or less than intended. Here's a tiny fix to multiply so that you jump the direction you were aiming.